### PR TITLE
Add support for `Caskfile` as file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Brewfile
 
-This Extension adds Ruby syntax highlighting for Brewfiles
+This Extension adds Ruby syntax highlighting for Homebrew bundle files (named as
+`Brewfile` or `Caskfile`).
 
 ![preview.png](https://github.com/sharat/vscode-brewfile/raw/master/preview.png)
 
 ## Credits
+
 This is inspired from [Orta's iOS Common Files](https://github.com/orta/vscode-ios-common-files)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
                     "ruby"
                 ],
                 "filenamePatterns": [
-                    "Brewfile"
+                    "Brewfile",
+                    "Caskfile"
                 ]
             }
         ]


### PR DESCRIPTION
Common to split casks and brew package bundling into separate files. This change simply recognises the `Caskfile` as a filename for syntax highlighting.

Note I have left the package version unmodified since I'm not sure how you go about version bumping and publishing.